### PR TITLE
convivial-bootstrap-32533: Replace jquery/once with core/once

### DIFF
--- a/components/calendar-item/calendar-item.js
+++ b/components/calendar-item/calendar-item.js
@@ -3,11 +3,11 @@
  * Add current or past class to calendar item date.
  */
 
-(function ($, Drupal) {
+(function ($, Drupal, once) {
 
   Drupal.behaviors.calendarItemCurrentDate = {
     attach: function attach(context) {
-      $('time.calendar-date', context).once('calendar-date').each(function () {
+      $(once('calendar-date', 'time.calendar-date', context)).each(function () {
         var $calendarDate = $(this);
         var dateTime = $calendarDate.attr('datetime');
         if (dateTime !== null) {
@@ -28,4 +28,4 @@
     }
   };
 
-})(jQuery, Drupal);
+})(jQuery, Drupal, once);

--- a/components/header/header.js
+++ b/components/header/header.js
@@ -3,7 +3,7 @@
  * JS for the Header.
  */
 
-(function ($) {
+(function ($, Drupal, once) {
   Drupal.behaviors.convivial_bootstrap_Header = {
     attach: function (context, settings) {
       /*
@@ -58,9 +58,8 @@
       };
 
       // Initial the jQuery Fixx plugin.
-      $('.bs-header--sticky ' + stickyElementSelector, context)
-        // .once() prevents this listener being attached multiple times...
-        .once('convivial_bootstrap_Header--fixx')
+        // once() prevents this listener being attached multiple times...
+      $(once('convivial_bootstrap_Header--fixx', '.bs-header--sticky ' + stickyElementSelector, context))
         .fixx({
           // Give the placeholder a class so we can specifically target only this one on the page.
           placeholderClass: 'bs-header-placeholder',
@@ -75,8 +74,7 @@
           startThreshold: 0
         });
 
-      $(window)
-        .once('convivial_bootstrap_Header--window-change')
+      $(once('convivial_bootstrap_Header--window-change', context))
         .on('resize scroll', function () {
           // Check if the Header is Sticky or not and alter the Header.
           if ($(stickyElementSelector).hasClass(stickyClass)) {
@@ -97,7 +95,7 @@
       * Primary Nav toggle.
       */
       // Add class to body when the nav toggler is clicked and nav is visible.
-      $('.navbar', context).once('convivial_bootstrap_header--navbar')
+      $(once('convivial_bootstrap_header--navbar', '.navbar', context))
         .on('show.bs.collapse', function () {
           $('body').addClass(navOpenClass);
           // Switch to theme header styling.
@@ -114,4 +112,4 @@
         });
       }
   };
-})(jQuery, Drupal);
+})(jQuery, Drupal, once);

--- a/components/search-autocomplete/search-autocomplete.js
+++ b/components/search-autocomplete/search-autocomplete.js
@@ -1,12 +1,11 @@
-(function ($, Drupal) {
+(function ($, Drupal, once) {
 
   'use strict';
 
   Drupal.behaviors.searchAutocomplete = {
     attach: function (context, settings) {
-      const searchFormInput = $('.block-bundle-search .searchform .searchform__query', context)
 
-      searchFormInput.once('searchFormInputFocusIn').focusin(function () {
+      $(once('searchFormInputFocusIn', '.block-bundle-search .searchform .searchform__query', context)).focusin(function () {
         $(this).autocomplete({
           source: function (request, response) {
             $.getJSON("/data/autocomplete?v=" + request.term, function (data) {
@@ -32,9 +31,9 @@
         };
       })
 
-      searchFormInput.once('searchFormInputFocusOut').focusout(function () {
+      $(once('searchFormInputFocusOut', '.block-bundle-search .searchform .searchform__query', context)).focusout(function () {
         $(this).autocomplete('destroy')
       })
     }
   };
-})(jQuery, Drupal);
+})(jQuery, Drupal, once);

--- a/components/search/search.js
+++ b/components/search/search.js
@@ -3,7 +3,7 @@
  * JS for Search Form.
  */
 
-(function ($, Drupal) {
+(function ($, Drupal, once) {
 
   'use strict';
 
@@ -64,40 +64,38 @@
             searchQueryInputSelector = '.searchform__query';
 
         // Search Form is visible on toggler button click.
-        searchform_toggler
-        // .once() prevents this listener being attached mutliple times...
-            .once('convivial_bootstrap_Search--toggler')
-            .on('click', function () {
-              // Toggle class on search form.
-              searchform_block.toggleClass('active');
+        // once() prevents this listener being attached mutliple times...
+        $(once('convivial_bootstrap_Search--toggler', '.searchform-toggler', context))
+          .on('click', function () {
+            // Toggle class on search form.
+            searchform_block.toggleClass('active');
 
-              // Create flag for whether search block is visible.
-              var searchVisible = $(searchform_block).hasClass('active');
+            // Create flag for whether search block is visible.
+            var searchVisible = $(searchform_block).hasClass('active');
 
-              // Toggle class on toggler button.
-              searchform_toggler.toggleClass('active', searchVisible);
+            // Toggle class on toggler button.
+            searchform_toggler.toggleClass('active', searchVisible);
 
-              // Toggle body class to assist in CSS styling when search form is visible.
-              // basically, remove the animated fade-in when Header gets Sticky.
-              $('body').toggleClass('searchform--open', searchVisible);
+            // Toggle body class to assist in CSS styling when search form is visible.
+            // basically, remove the animated fade-in when Header gets Sticky.
+            $('body').toggleClass('searchform--open', searchVisible);
 
-              // Focus on search input field if the form block is visible "active".
-              if (searchVisible) {
-                searchform_block.find(searchQueryInputSelector).focus();
-              }
-            });
+            // Focus on search input field if the form block is visible "active".
+            if (searchVisible) {
+              searchform_block.find(searchQueryInputSelector).focus();
+            }
+          });
 
         // Disable search form submit if text is empty.
-        $(searchform_block, context)
-            .once('convivial_bootstrap_Search--submit')
-            .on('submit', 'form', function (e) {
-              if (!$(searchQueryInputSelector, this).val()) {
-                // Prevent the form from submitting.
-                e.preventDefault();
-              }
-            });
+        $(once('convivial_bootstrap_Search--submit', '.block-bundle-search', context))
+          .on('submit', 'form', function (e) {
+            if (!$(searchQueryInputSelector, this).val()) {
+              // Prevent the form from submitting.
+              e.preventDefault();
+            }
+          });
       }
 
     }
   };
-})(jQuery, Drupal);
+})(jQuery, Drupal, once);

--- a/convivial_bootstrap.libraries.yml
+++ b/convivial_bootstrap.libraries.yml
@@ -39,7 +39,7 @@ base-bootstrap5-js:
     js/convivial-bootstrap.js: { }
   dependencies:
     - core/jquery
-    - core/jquery.once
+    - core/once
     - core/drupal
 
 billboard:
@@ -58,8 +58,9 @@ billboard-apply:
     components/billboard/billboard.apply.js: { }
   dependencies:
     - core/jquery
-    - core/jquery.once
+    - core/drupal
     - core/drupalSettings
+    - core/once
     - convivial_bootstrap/d3
     - convivial_bootstrap/billboard
 
@@ -68,7 +69,8 @@ calendar-item:
     components/calendar-item/calendar-item.js: { }
   dependencies:
     - core/jquery
-    - core/jquery.once
+    - core/drupal
+    - core/once
 
 content-tabs:
   version: VERSION
@@ -154,8 +156,8 @@ header:
     components/header/header.js: { }
   dependencies:
     - core/jquery
-    - core/jquery.once
     - core/drupal
+    - core/once
 
 lightbox:
   js:
@@ -214,12 +216,16 @@ search:
     components/search/search.js: { }
   dependencies:
     - core/jquery
+    - core/drupal
+    - core/once
 
 search_autocomplete:
   js:
     components/search-autocomplete/search-autocomplete.js: { }
   dependencies:
     - core/jquery
+    - core/drupal
+    - core/once
 
 smooth-scroll:
   js:
@@ -240,11 +246,18 @@ scroll_anchor:
     js/scroll-anchor.js: { }
   dependencies:
     - core/jquery
+    - core/drupal
+    - core/drupalSettings
+    - core/once
     - convivial_bootstrap/sticky_header_height
 
 sticky_header_height:
   js:
     js/sticky-header-height.js: { }
+  dependencies:
+    - core/jquery
+    - core/drupal
+    - core/drupalSettings
 
 slick_carousel:
   js:
@@ -265,6 +278,6 @@ decision-tree:
     components/decision-tree/decision-tree.js: { }
   dependencies:
     - core/jquery
-    - core/jquery.once
+    - core/drupal
     - core/js-cookie
     - core/drupalSettings

--- a/js/scroll-anchor.js
+++ b/js/scroll-anchor.js
@@ -1,13 +1,13 @@
 /*
 * Global smooth scroll element to the destination anchor.
 */
-(function ($, Drupal, drupalSettings) {
+(function ($, Drupal, drupalSettings, once) {
   Drupal.behaviors.scrollAnchor = {
     attach: function (context, settings) {
       const stickyHeaderHeight = drupalSettings.stickyHeaderHeight || 0
       const scrollTopPadding = 16 + stickyHeaderHeight
 
-      $(document).once('scrollAnchorOnce').on('click', 'a[href^="#"]', function (event) {
+      $(once('scrollAnchorOnce', context)).on('click', 'a[href^="#"]', function (event) {
         event.preventDefault();
 
         $('html, body').animate({
@@ -16,4 +16,4 @@
       });
     }
   };
-})(jQuery, Drupal, drupalSettings)
+})(jQuery, Drupal, drupalSettings, once)


### PR DESCRIPTION
core/jquery.once library is removed from drupal core 10. Use the core/once library instead
Change record - https://www.drupal.org/node/3158256