### PR TITLE
convivial-demo-33541: Exclude style.css from being rendered by Convivial Theme Default Render module.

### DIFF
--- a/convivial_bootstrap.info.yml
+++ b/convivial_bootstrap.info.yml
@@ -3,9 +3,9 @@ type: theme
 description: 'Convivial theme based on Bootstrap 5.'
 core_version_requirement: ^9.5 || ^10
 libraries:
-  - convivial_bootstrap/global-styling
-  - convivial_bootstrap/back-to-top
+  - convivial_bootstrap/base-global-styling
   - convivial_bootstrap/base-bootstrap5-js
+  - convivial_bootstrap/back-to-top
   - convivial_bootstrap/font-family
   - convivial_bootstrap/header
   - convivial_bootstrap/jquery_ui
@@ -13,8 +13,6 @@ libraries:
   - convivial_bootstrap/search
   - convivial_bootstrap/search_autocomplete
   - convivial_bootstrap/slider
-ckeditor_stylesheets:
-  - css/style.css
 ckeditor5-stylesheets:
   - css/style.css
 base theme: false

--- a/convivial_bootstrap.libraries.yml
+++ b/convivial_bootstrap.libraries.yml
@@ -1,4 +1,4 @@
-global-styling:
+base-global-styling:
   css:
     component:
       css/style.css: { }


### PR DESCRIPTION
Mirrored from morpht/convivial-demo@356e3ba (33683-library-change).